### PR TITLE
Performance improvements

### DIFF
--- a/src/Wplace Palette Converter/Extensions/ColorExt.cs
+++ b/src/Wplace Palette Converter/Extensions/ColorExt.cs
@@ -1,4 +1,5 @@
 ﻿using Colourful;
+using Colourful.Internals;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -10,24 +11,43 @@ namespace WplacePaletteConverter.Extensions
 {
 	internal static class ColorExt
 	{
-		public static Color GetMostSimilar(this Color input, Models.WplaceColor[] wpColors, Enums.ComparisonMethods method)
+        // PERF: Initialize the color difference algorithm once to save time, memory,
+        // and reduce GC pressure. This avoids creating a new instance every time
+        // we need to calculate the distance between two colors.
+        private static readonly CIEDE2000ColorDifference cIEDE2000ColorDifference = new();
+        private static readonly CIE94ColorDifference cIE94ColorDifference = new();
+        private static readonly CIE76ColorDifference cIE76ColorDifference = new();
+        private static readonly JzCzhzDEzColorDifference jzCzhzDEzColorDifference = new();
+        private static readonly EuclideanDistanceColorDifference<XYZColor> euclideanDistanceColorDifference = new();
+
+        // PERF: Do the same for converters.
+        private static readonly IColorConverter<RGBColor, LabColor> rgbToLabConverter = new ConverterBuilder().FromRGB().ToLab().Build();
+        private static readonly IColorConverter<RGBColor, JzCzhzColor> rgbToJzCzhzConverter = new ConverterBuilder().FromRGB().ToJzCzhz().Build();
+        private static readonly IColorConverter<RGBColor, XYZColor> rgbToXYZConverter = new ConverterBuilder().FromRGB().ToXYZ(RGBWorkingSpaces.sRGB.WhitePoint).Build();
+
+        public static Color GetMostSimilar(this Color input, Models.WplaceColor[] wpColors, Enums.ComparisonMethods method)
 		{
 			Color? closestColor = null;
 			double closestDistance = double.MaxValue;
 
-			foreach (Models.WplaceColor wpColor in wpColors)
-			{
-				double distance = method switch
-				{
-					Enums.ComparisonMethods.CIEDE2000 => new CIEDE2000ColorDifference().ComputeDifference(input.ToLabColor(), wpColor.LabColor),
-					Enums.ComparisonMethods.CIE94 => new CIE94ColorDifference().ComputeDifference(input.ToLabColor(), wpColor.LabColor),
-					Enums.ComparisonMethods.CIE76 => new CIE76ColorDifference().ComputeDifference(input.ToLabColor(), wpColor.LabColor),
-					Enums.ComparisonMethods.JzCzhzDEz => new JzCzhzDEzColorDifference().ComputeDifference(input.ToJzCzhzColor(), wpColor.JzColor),
-					Enums.ComparisonMethods.Euclidean => new EuclideanDistanceColorDifference<XYZColor>().ComputeDifference(input.ToXYZColor(), wpColor.XYZColor),
-					_ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
-				};
+            // PERF: Precompute LabColor once from the input, even if it's not always used.
+            // This is the most expensive color conversion, and it's also the most commonly
+            // used—since the first three conversion options typically depend on it.
+            LabColor labColor = input.ToLabColor();
 
-				if (distance < closestDistance)
+            foreach (Models.WplaceColor wpColor in wpColors)
+			{
+                double distance = method switch
+                {
+                    Enums.ComparisonMethods.CIEDE2000 => cIEDE2000ColorDifference.ComputeDifference(labColor, wpColor.LabColor),
+                    Enums.ComparisonMethods.CIE94 => cIE94ColorDifference.ComputeDifference(labColor, wpColor.LabColor),
+                    Enums.ComparisonMethods.CIE76 => cIE76ColorDifference.ComputeDifference(labColor, wpColor.LabColor),
+                    Enums.ComparisonMethods.JzCzhzDEz => jzCzhzDEzColorDifference.ComputeDifference(input.ToJzCzhzColor(), wpColor.JzColor),
+                    Enums.ComparisonMethods.Euclidean => euclideanDistanceColorDifference.ComputeDifference(input.ToXYZColor(), wpColor.XYZColor),
+                    _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+                };
+
+                if (distance < closestDistance)
 				{
 					closestDistance = distance;
 					closestColor = wpColor.Color;
@@ -40,13 +60,16 @@ namespace WplacePaletteConverter.Extensions
 			return closestColor.Value;
 		}
 
-		public static LabColor ToLabColor(this Color color) =>
-			new ConverterBuilder().FromRGB().ToLab().Build().Convert(new(color));
+		
+        public static LabColor ToLabColor(this Color color) =>
+            rgbToLabConverter.Convert(new(color));
 
-		public static JzCzhzColor ToJzCzhzColor(this Color color) =>
-			new ConverterBuilder().FromRGB().ToJzCzhz().Build().Convert(new(color));
+        
+        public static JzCzhzColor ToJzCzhzColor(this Color color) =>
+            rgbToJzCzhzConverter.Convert(new(color));
 
-		public static XYZColor ToXYZColor(this Color color) =>
-			new ConverterBuilder().FromRGB().ToXYZ(RGBWorkingSpaces.sRGB.WhitePoint).Build().Convert(new(color));
+        
+        public static XYZColor ToXYZColor(this Color color) =>
+            rgbToXYZConverter.Convert(new(color));
 	}
 }


### PR DESCRIPTION
**Precomputed LabColor conversion:**
LabColor is now computed once per input and reused across computations, even when not always needed. This avoids redundant and expensive conversions, especially since it's used in the majority of comparison paths.

**Static initialization of color difference algorithms:**
Expensive algorithms like CIEDE2000ColorDifference are now instantiated once at runtime and reused. This reduces per-call allocations and GC pressure.

**Manual ARGB value computation:**
ARGB values are now computed directly from individual color components, bypassing unnecessary calls to ToArgb() and avoiding redundant conversions via the Color struct.

**Caching performance note:**
Identified a performance bottleneck related to cache lookups for color comparisons. A TODO has been added suggesting the introduction of a custom caching mechanism to optimize retrieval speed.

For 6MB image, I've noted 14x perf. gain.
For 320KB image, I've noted 18x perf. gain.

Results will vary ofcourse depending on the number of colours in the image and core counts.
